### PR TITLE
create ReadFile to Read a file,  Handle UTF-8 BOM and Validate UTF-8 Encoding

### DIFF
--- a/utils/readFile.go
+++ b/utils/readFile.go
@@ -1,0 +1,14 @@
+package utils
+
+import (
+	"errors"
+	"os"
+)
+
+func ReadFile(path string) ([]byte, error) {
+	file, err := os.ReadFile(path)
+	if err != nil {
+		return nil, errors.New("error reading content of the file")
+	}
+	return file, nil
+}

--- a/utils/readFile.go
+++ b/utils/readFile.go
@@ -1,8 +1,10 @@
 package utils
 
 import (
+	"bytes"
 	"errors"
 	"os"
+	"unicode/utf8"
 )
 
 func ReadFile(path string) ([]byte, error) {
@@ -10,5 +12,13 @@ func ReadFile(path string) ([]byte, error) {
 	if err != nil {
 		return nil, errors.New("error reading content of the file")
 	}
+
+	utf8BOM := []byte{0xEF, 0xBB, 0xBF}
+	file = bytes.TrimPrefix(file, utf8BOM)
+
+	if !utf8.Valid(file) {
+		return nil, errors.New("file contains invalid UTF-8")
+	}
+
 	return file, nil
 }


### PR DESCRIPTION
This PR improves the ReadFile function by:

- Removing the UTF-8 Byte Order Mark (BOM) if present, ensuring consistent content handling.
- Adding a check for valid UTF-8 encoding, returning an error if the file contains invalid UTF-8 characters.
- Keeping the error message "error reading content of the file" when file reading fails.

These changes enhance the function's robustness, ensuring correctly formatted content is returned.