### PR TITLE
 Add CheckFlags Function for Command-Line Argument Parsing

### DIFF
--- a/utils/checkFlags.go
+++ b/utils/checkFlags.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 )
 
+// CheckFlags validates the flags passed to the program
 func CheckFlags(args []string) error {
 	fs := flag.NewFlagSet("textindex", flag.ContinueOnError)
 

--- a/utils/checkFlags.go
+++ b/utils/checkFlags.go
@@ -1,0 +1,39 @@
+package utils
+
+import (
+	"errors"
+	"flag"
+)
+
+func CheckFlags(args []string) error {
+	fs := flag.NewFlagSet("textindex", flag.ContinueOnError)
+
+	// Expected flags
+	command := fs.String("c", "", "Specify the command (index or lookup)")
+	input := fs.String("i", "", "Specify the input file")
+	chunkSize := fs.String("s", "", "Specify the chunk size")
+	output := fs.String("o", "", "Specify the output file")
+	query := fs.String("q", "", "Specify the query text")
+
+	if err := fs.Parse(args[1:]); err != nil {
+		return errors.New("flag not used")
+	}
+
+	// Usage message for error handling
+	const usageMsg = "usage: textindex  -c index  -i <input_file.txt>  -s <chunk-size>  -o <index_file.idx>\ntextindex  -c lookup  -i <index_file.idx> -q <query_text>"
+
+	switch *command {
+	case "index":
+		if *input == "" || *chunkSize == "" || *output == "" {
+			return errors.New(usageMsg)
+		}
+	case "lookup":
+		if *input == "" || *query == "" {
+			return errors.New(usageMsg)
+		}
+	default:
+		return errors.New("flag not used")
+	}
+
+	return nil
+}


### PR DESCRIPTION
This `PR` introduces the `CheckFlags` function in the `utils` package. The function is responsible for `parsing` and `validating` command-line flags for the `textindex tool`, ensuring proper usage and error handling.

**Changes Made**

- Implemented `CheckFlags` to handle command-line arguments.
- Defined required flags for index and lookup commands.
-  Included validation and error messages to guide users on correct flag usage.