### PR TITLE
Feature/decode binary

### DIFF
--- a/utils/decodeBinary.go
+++ b/utils/decodeBinary.go
@@ -1,0 +1,28 @@
+package utils
+
+import (
+	"encoding/gob"
+	"errors"
+	"os"
+	"path/filepath"
+)
+
+func DecodeBinary(path string) (map[uint64]Entry, error) {
+	if filepath.Ext(path) != ".idx" {
+		return nil, errors.New("wrong type of file")
+	}
+
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, errors.New("error while decoding file")
+	}
+	defer file.Close()
+
+	decoder := gob.NewDecoder(file)
+	var result map[uint64]Entry
+	if err := decoder.Decode(&result); err != nil {
+		return nil, errors.New("error while decoding file")
+	}
+
+	return result, nil
+}

--- a/utils/decodeBinary_test.go
+++ b/utils/decodeBinary_test.go
@@ -7,22 +7,16 @@ import (
 
 func TestDecodeBinary(t *testing.T) {
 	cases := []struct {
-		name   string
-		path   string
-		expect map[uint64]struct {
-			value  []byte
-			offset int
-		}
+		name      string
+		path      string
+		expect    map[uint64]Entry
 		expectErr error
 	}{
 		{
 			name: "Valid idx file",
 			path: "testdata/index.idx",
-			expect: map[uint64]struct {
-				value  []byte
-				offset int
-			}{
-				123456789: {value: []byte("example content"), offset: 42},
+			expect: map[uint64]Entry{
+				123456789: {[]byte("example content"), 42},
 			},
 			expectErr: nil,
 		},
@@ -57,11 +51,11 @@ func TestDecodeBinary(t *testing.T) {
 					if !exists {
 						t.Errorf("%s: expected key %d to exist, but it does not", c.name, key)
 					}
-					if string(resVal.value) != string(val.value) {
-						t.Errorf("%s: expected value %q, got %q", c.name, string(val.value), string(resVal.value))
+					if string(resVal.Value) != string(val.Value) {
+						t.Errorf("%s: expected value %q, got %q", c.name, string(val.Value), string(resVal.Value))
 					}
-					if resVal.offset != val.offset {
-						t.Errorf("%s: expected offset %d, got %d", c.name, val.offset, resVal.offset)
+					if resVal.Offset != val.Offset {
+						t.Errorf("%s: expected offset %d, got %d", c.name, val.Offset, resVal.Offset)
 					}
 				}
 			}


### PR DESCRIPTION
This PR introduces the _DecodeBinary_ function to the _utils_ package. The function is responsible for decoding ._idx_ files using Go's _gob_ encoding and returning their content as a _map[uint64]Entry._
Key Features:
 **File Type Validation:**
-  Ensures the file has a _.idx_ extension before attempting to decode.

 **Decoding Logic:**
 Uses _gob.NewDecoder_ to deserialize the file contents into a _map[uint64]Entry._

 **Error Handling:**

-  Returns _"wrong type of file"_ for non-.idx files.
-  Returns _"error while decoding file"_ for file read or decode failures.